### PR TITLE
Fix service worker icon path

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -2,7 +2,7 @@ const CACHE_NAME = 'cleartranscript-v2';
 const urlsToCache = [
   '/',
   '/index.html',
-  '/icon-maskable.png',
+  '/maskable-icon.png',
   '/icon-192x192.png'
 ];
 


### PR DESCRIPTION
## Summary
- fix cached maskable icon path in service worker

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bb75dbbc883288cccf712790e1c43