### PR TITLE
Fix invalid date error in summary generation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1376,7 +1376,12 @@
         }
 
         function getDateKey(date) {
-            const d = new Date(date);
+            let d;
+            if (date && date.seconds) {
+                d = new Date(date.seconds * 1000);
+            } else {
+                d = new Date(date);
+            }
             return d.toISOString().split('T')[0];
         }
 


### PR DESCRIPTION
## Summary
- handle Firestore timestamps in `getDateKey`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688441c8f24883289b99a36f9d3f5b70