### PR TITLE
Reset icon and title after closing transcript modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1494,7 +1494,11 @@
             modal.style.display = 'none';
             const url = new URL(window.location);
             url.searchParams.delete('id');
-            
+
+            // Reset favicon and title when modal is closed
+            setFavicon('idle');
+            setTitle(baseTitle);
+
             if (loadedWithRecordingId) {
                 // Refresh the page if we initially loaded with an ID
                 window.location.href = url.toString();


### PR DESCRIPTION
## Summary
- Reset favicon to idle icon when transcript modal is dismissed
- Restore page title to base state when modal closes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9611129b483288830dfd4b8ec089a