### PR TITLE
feat: track transcript copies

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -505,6 +505,18 @@
             fill: #28a745;
         }
 
+        .copy-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        .copy-count {
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-top: 2px;
+        }
+
         .loading-indicator {
             display: none;
             float: right;
@@ -654,16 +666,19 @@
                                 <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z"/>
                             </svg>
                         </button>
-                        <!-- Existing Copy Button -->
-                        <button class="copy-button" id="copy-button" data-tooltip="Copy" aria-label="Copy content">
-                            <svg aria-hidden="true" focusable="false" class="copy-button-copy" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"> <!-- Changed fill -->
-                                <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
-                                <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
-                            </svg>
-                            <svg aria-hidden="true" focusable="false" class="copy-button-check" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
-                                <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
-                            </svg>
-                        </button>
+                        <!-- Existing Copy Button with counter -->
+                        <div class="copy-container">
+                            <button class="copy-button" id="copy-button" data-tooltip="Copy" aria-label="Copy content">
+                                <svg aria-hidden="true" focusable="false" class="copy-button-copy" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"> <!-- Changed fill -->
+                                    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
+                                    <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+                                </svg>
+                                <svg aria-hidden="true" focusable="false" class="copy-button-check" viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+                                    <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
+                                </svg>
+                            </button>
+                            <span id="copy-count" class="copy-count">0</span>
+                        </div>
                     </div>
                 </div>
                 <div class="recording-date" id="recording-date">10/27/2024 · 19:33</div>
@@ -796,7 +811,7 @@
                     }
 
                     const querySnapshot = await getDocs(q);
-                    const dataArray = querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                    const dataArray = querySnapshot.docs.map(doc => ({ id: doc.id, copyCount: 0, ...doc.data() }));
                     resolve(dataArray);
                 } catch (error) {
                     reject(error);
@@ -811,7 +826,8 @@
                     const docSnap = await getDoc(docRef);
                     
                     if (docSnap.exists()) {
-                        resolve({ id: docSnap.id, ...docSnap.data() });
+                        const data = { id: docSnap.id, copyCount: 0, ...docSnap.data() };
+                        resolve(data);
                     } else {
                         reject(new Error('Recording not found'));
                     }
@@ -837,6 +853,20 @@
                 });
                 console.log("Document updated with ID: ", recording.id);
                 resolve(recording.id);
+            });
+        }
+
+        function updateCopyCountInDB(recording) {
+            return new Promise(async (resolve, reject) => {
+                try {
+                    const docRef = doc(db, "recordings", recording.id);
+                    await updateDoc(docRef, {
+                        copyCount: recording.copyCount || 0
+                    });
+                    resolve(recording.id);
+                } catch (error) {
+                    reject(error);
+                }
             });
         }
 
@@ -916,6 +946,7 @@
             getSingleRecordingFromDB,
             saveRecordingToDB,
             updateRecordingInDB,
+            updateCopyCountInDB,
             generateTitle,
             getSummaryFromDB,
             saveSummaryToDB
@@ -945,6 +976,7 @@
         const modalTranscript = document.getElementById('modal-transcript');
         const modalAudio = document.getElementById('modal-audio');
         const copyButton = document.getElementById('copy-button');
+        const copyCountEl = document.getElementById('copy-count');
         const chatGPTButton = document.getElementById('chatgpt-button');
         const loadingIndicator = document.getElementById('loading-indicator');
         const loadAllButton = document.getElementById('load-all-button');
@@ -1002,11 +1034,28 @@
         let recordingInterval;
         let loadedWithRecordingId = false;
         let summaries = {};
+        const copyUpdateTimers = {};
         const summaryIconSVG = `
             <svg class="summary-icon" viewBox="0 0 1024 1024" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg">
                 <path d="M526.791111 1005.037037h-329.955555c-61.62963 0-111.691852-50.062222-111.691852-111.691852V246.518519c0-61.62963 50.062222-111.691852 111.691852-111.691852h145.066666c21.617778-57.457778 74.145185-132.740741 168.770371-132.740741 101.451852 0 147.152593 85.712593 164.598518 132.740741h132.361482c61.62963 0 111.691852 50.062222 111.691851 111.691852v376.794074c0 20.859259-17.066667 37.925926-37.925925 37.925926s-37.925926-17.066667-37.925926-37.925926V246.518519c0-19.721481-16.118519-35.84-35.84-35.84h-160.237037c-17.825185 0-33.185185-12.515556-36.977778-29.771852-0.948148-3.982222-24.082963-102.968889-99.745185-102.968889-80.213333 0-103.537778 101.831111-103.727408 102.968889a37.736296 37.736296 0 0 1-36.977778 29.771852h-173.131851c-19.721481 0-35.84 16.118519-35.84 35.84v646.637037c0 19.721481 16.118519 35.84 35.84 35.84h329.955555c20.859259 0 37.925926 17.066667 37.925926 37.925925s-17.066667 38.115556-37.925926 38.115556z" fill="black"/>
                 <path d="M545.754074 211.057778h-76.420741c-10.24 0-18.773333-8.343704-18.773333-18.773334v-0.568888c0-10.24 8.343704-18.773333 18.773333-18.773334h76.420741c10.24 0 18.773333 8.343704 18.773333 18.773334v0.568888c0 10.24-8.533333 18.773333-18.773333 18.773334zM754.346667 387.602963H260.740741c-10.24 0-18.773333-8.343704-18.773334-18.773333v-0.568889c0-10.24 8.343704-18.773333 18.773334-18.773334h493.605926c10.24 0 18.773333 8.343704 18.773333 18.773334v0.568889c0 10.42963-8.533333 18.773333-18.773333 18.773333zM754.346667 564.337778H260.740741c-10.24 0-18.773333-8.343704-18.773334-18.773334v-0.568888c0-10.24 8.343704-18.773333 18.773334-18.773334h493.605926c10.24 0 18.773333 8.343704 18.773333 18.773334v0.568888c0 10.42963-8.533333 18.773333-18.773333 18.773334zM521.481481 741.072593H255.620741c-10.24 0-18.773333-8.343704-18.773334-18.773334v-0.568889c0-10.24 8.343704-18.773333 18.773334-18.773333H521.481481c10.24 0 18.773333 8.343704 18.773334 18.773333v0.568889c0 10.24-8.343704 18.773333-18.773334 18.773334zM769.137778 987.780741c-3.982222 0-8.154074-1.327407-11.567408-3.982222l-104.485926-80.213334a18.811259 18.811259 0 0 1-3.413333-26.548148c6.447407-8.343704 18.204444-9.860741 26.548148-3.413333l89.884445 69.214815 156.065185-189.44a18.962963 18.962963 0 0 1 26.737778-2.654815 18.962963 18.962963 0 0 1 2.654814 26.737777l-167.632592 203.662223c-3.982222 4.171852-9.291852 6.637037-14.791111 6.637037z" fill="black"/>
             </svg>`;
+
+        function scheduleCopyCountUpdate(recording) {
+            if (!recording.id) return;
+            clearTimeout(copyUpdateTimers[recording.id]);
+            copyUpdateTimers[recording.id] = setTimeout(() => {
+                window.app.updateCopyCountInDB(recording).catch(err => console.error('Failed to update copy count:', err));
+            }, 1000);
+        }
+
+        function incrementCopyCount(recording) {
+            recording.copyCount = (recording.copyCount || 0) + 1;
+            if (modal.style.display === 'flex' && recordings[modal.dataset.index] === recording) {
+                copyCountEl.textContent = recording.copyCount;
+            }
+            scheduleCopyCountUpdate(recording);
+        }
 
         // Mock JSON Data
         const mockData = [
@@ -1194,11 +1243,12 @@
                 // Step 2: Create initial recording object
                 const initialTitle = generateLocalTitle(file.name);
                 const date = new Date().toISOString();
-                const recording = { 
-                    title: initialTitle, 
-                    transcript: 'Processing transcript...', 
-                    audioURL, 
-                    date 
+                const recording = {
+                    title: initialTitle,
+                    transcript: 'Processing transcript...',
+                    audioURL,
+                    date,
+                    copyCount: 0
                 };
 
                 recordings.push(recording);
@@ -1345,6 +1395,7 @@
                     navigator.clipboard.writeText(rec.transcript).then(() => {
                         copyButton.classList.add('copied');
                         setTimeout(() => copyButton.classList.remove('copied'), 2500);
+                        incrementCopyCount(rec);
                     });
                 });
 
@@ -1479,6 +1530,7 @@
             modalAudio.src = rec.audioURL;
             modalAudio.playbackRate = 1.75;
             modal.dataset.index = index;
+            copyCountEl.textContent = rec.copyCount || 0;
             modal.style.display = 'flex';
             
             // Only update URL if requested and we have a recording ID
@@ -1700,11 +1752,13 @@
 
         // Copy Transcript
         copyButton.addEventListener('click', () => {
+            const rec = recordings[modal.dataset.index];
             navigator.clipboard.writeText(modalTranscript.textContent).then(() => {
                 copyButton.classList.add('copied');
                 setTimeout(() => {
                     copyButton.classList.remove('copied');
                 }, 2500);
+                incrementCopyCount(rec);
             }).catch(err => {
                 console.error('Could not copy text:', err);
             });


### PR DESCRIPTION
## Summary
- display per-transcript copy count in modal
- increment count on any copy action and debounce Firestore updates
- persist new `copyCount` field when creating or loading transcripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1712ef808328a6a2cb70e60a5b81